### PR TITLE
Fix bodyParser.json limit size

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ var http = require('http').Server(app);
 var io = require('socket.io')(http);
 var port = process.env.PORT || 3000;
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({limit: '50mb'}));
 
 app.use(express.static(__dirname + '/public'));
 


### PR DESCRIPTION
This size limit avoid the following error :

```
pinkfire_1 | Error: request entity too large
pinkfire_1 |     at makeError (/usr/src/node_modules/body-parser/node_modules/raw-body/index.js:184:15)
pinkfire_1 |     at module.exports (/usr/src/node_modules/body-parser/node_modules/raw-body/index.js:40:15)
pinkfire_1 |     at read (/usr/src/node_modules/body-parser/lib/read.js:62:3)
pinkfire_1 |     at jsonParser (/usr/src/node_modules/body-parser/lib/types/json.js:96:5)
pinkfire_1 |     at Layer.handle [as handle_request] (/usr/src/node_modules/express/lib/router/layer.js:82:5)
pinkfire_1 |     at trim_prefix (/usr/src/node_modules/express/lib/router/index.js:302:13)
pinkfire_1 |     at /usr/src/node_modules/express/lib/router/index.js:270:7
```

See https://github.com/expressjs/body-parser#limit-3
